### PR TITLE
Remove `pkgin autoremove`'s '-y' option

### DIFF
--- a/_layouts/install.html
+++ b/_layouts/install.html
@@ -93,7 +93,7 @@ $ sudo pkgin -y full-upgrade
 $ sudo pkgin -y remove ffmpeg2
 
 : Automatically remove orphaned dependencies
-$ sudo pkgin -y autoremove
+$ sudo pkgin autoremove
 {% endhighlight %}
 				</div>
 				<div class="col-md-6">


### PR DESCRIPTION
From `pkgin(1)`:

```
  -y     Assumes "yes" as default answer, except for autoremove
```

The option is in reality ignored.